### PR TITLE
Remove deprecated keyword parameter providing_args

### DIFF
--- a/django_bouncy/signals.py
+++ b/django_bouncy/signals.py
@@ -3,10 +3,10 @@
 from django.dispatch import Signal
 
 # Any notification received
-notification = Signal(providing_args=["notification", "request"])
+notification = Signal()
 
 # New SubscriptionConfirmation received
-subscription = Signal(providing_args=["result", "notification"])
+subscription = Signal()
 
 # New bounce or complaint received
-feedback = Signal(providing_args=["instance", "message", "notification"])
+feedback = Signal()


### PR DESCRIPTION
Django 4.0 removed the keyword argument `providing_args` from `django.dispatch.Signal`, but this package still used it. `providing_args` existed only for documentation purposes and can be removed without replacement.