### PR TITLE
Remove @python_2_unicode_compatible decorator

### DIFF
--- a/django_bouncy/models.py
+++ b/django_bouncy/models.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
 class Feedback(models.Model):
@@ -25,7 +24,6 @@ class Feedback(models.Model):
         abstract = True
 
 
-@python_2_unicode_compatible
 class Bounce(Feedback):
     """A bounce report for an individual email address"""
     hard = models.BooleanField(db_index=True, verbose_name="Hard Bounce")
@@ -48,7 +46,6 @@ class Bounce(Feedback):
             self.address, self.bounce_type, self.mail_from)
 
 
-@python_2_unicode_compatible
 class Complaint(Feedback):
     """A complaint report for an individual email address"""
     useragent = models.TextField(blank=True, null=True)
@@ -64,7 +61,6 @@ class Complaint(Feedback):
             self.address, self.mail_from)
 
 
-@python_2_unicode_compatible
 class Delivery(Feedback):
     """A delivery report for an individual email address"""
     delivered_time = models.DateTimeField(blank=True, null=True)


### PR DESCRIPTION
This decorator moved from Django to Six, so the import does not work with newer Django versions. Since we don't need to support Python 2, I removed the decorator instead of adding a dependency on Six to this package.