### PR TITLE
feat: drop Python 2 support and modernize dependencies

### DIFF
--- a/django_bouncy/models.py
+++ b/django_bouncy/models.py
@@ -1,6 +1,4 @@
 """Models for the django_bouncy app"""
-from __future__ import unicode_literals
-
 from django.db import models
 
 
@@ -19,7 +17,7 @@ class Feedback(models.Model):
     feedback_timestamp = models.DateTimeField(
         verbose_name="Feedback Time", null=True, blank=True)
 
-    class Meta(object):
+    class Meta:
         """Meta info for Feedback Abstract Model"""
         abstract = True
 
@@ -72,6 +70,6 @@ class Delivery(Feedback):
         return "%s Delivery (email sender: from %s)" % (
             self.address, self.mail_from)
 
-    class Meta(object):
+    class Meta:
         """Meta info for the Delivery model"""
         verbose_name_plural = 'deliveries'

--- a/django_bouncy/tests/utils.py
+++ b/django_bouncy/tests/utils.py
@@ -1,12 +1,7 @@
 """Tests for utils.py in the django-bouncy app"""
 from django.conf import settings
 from django.dispatch import receiver
-try:
-    # Python 2.6/2.7
-    from mock import Mock, patch
-except ImportError:
-    # Python 3
-    from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from django_bouncy.tests.helpers import BouncyTestCase, loader
 from django_bouncy import utils, signals

--- a/django_bouncy/tests/views.py
+++ b/django_bouncy/tests/views.py
@@ -7,13 +7,7 @@ from django.test.utils import override_settings
 from django.http import Http404
 from django.conf import settings
 from django.dispatch import receiver
-try:
-    # Python 2.6/2.7
-    from mock import patch
-except ImportError:
-    # Python 3
-    # from unittest.mock import patch
-    from mock import patch
+from unittest.mock import patch
 
 from django_bouncy.tests.helpers import BouncyTestCase, loader
 from django_bouncy import views, signals
@@ -38,7 +32,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
 
     def test_success(self):
         """Test a successful request"""
-        self.request._body = json.dumps(self.notification)
+        self.request._body = json.dumps(self.notification).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.content.decode('ascii'), 'Bounce Processed')
@@ -50,7 +44,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         Based on http://stackoverflow.com/questions/3817213/
         """
         # pylint: disable=attribute-defined-outside-init, unused-variable
-        self.request._body = json.dumps(self.notification)
+        self.request._body = json.dumps(self.notification).encode()
         self.signal_count = 0
 
         @receiver(signals.notification)
@@ -71,7 +65,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
     @override_settings(BOUNCY_TOPIC_ARN=['Bad ARN'])
     def test_bad_topic(self):
         """Test the response if the topic does not match the settings"""
-        self.request._body = json.dumps(self.notification)
+        self.request._body = json.dumps(self.notification).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 400)
         self.assertEqual(result.content.decode('ascii'), 'Bad Topic')
@@ -79,21 +73,21 @@ class BouncyEndpointViewTest(BouncyTestCase):
     def test_no_header(self):
         """Test the results if the request does not have a topic header"""
         request = self.factory.post('/')
-        request._body = json.dumps(self.notification)
+        request._body = json.dumps(self.notification).encode()
         result = views.endpoint(request)
         self.assertEqual(result.status_code, 400)
         self.assertEqual(result.content.decode('ascii'), 'No TopicArn Header')
 
     def test_invalid_json(self):
         """Test if the notification does not have a JSON body"""
-        self.request._body = "This Is Not JSON"
+        self.request._body = b"This Is Not JSON"
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 400)
         self.assertEqual(result.content.decode('ascii'), 'Not Valid JSON')
 
     def test_missing_necessary_key(self):
         """Test if the notification is missing vital keys"""
-        self.request._body = json.dumps({})
+        self.request._body = json.dumps({}).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 400)
         self.assertEqual(
@@ -103,7 +97,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         """Test an unknown notification type"""
         notification = loader('bounce_notification')
         notification['Type'] = 'NotAKnownType'
-        self.request._body = json.dumps(notification)
+        self.request._body = json.dumps(notification).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 400)
         self.assertEqual(
@@ -113,7 +107,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         """Test an unknown certificate hostname"""
         notification = loader('bounce_notification')
         notification['SigningCertURL'] = 'https://baddomain.com/cert.pem'
-        self.request._body = json.dumps(notification)
+        self.request._body = json.dumps(notification).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 400)
         self.assertEqual(
@@ -128,7 +122,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         settings.BOUNCY_AUTO_SUBSCRIBE = False
         with self.assertRaises(Http404):
             notification = loader('subscriptionconfirmation')
-            self.request._body = json.dumps(notification)
+            self.request._body = json.dumps(notification).encode()
             views.endpoint(self.request)
         settings.BOUNCY_AUTO_SUBSCRIBE = original_setting
 
@@ -137,7 +131,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         """Test that a approve_subscription is called"""
         mock.return_value = 'Test Return Value'
         notification = loader('subscriptionconfirmation')
-        self.request._body = json.dumps(notification)
+        self.request._body = json.dumps(notification).encode()
         result = views.endpoint(self.request)
         self.assertTrue(mock.called)
         self.assertEqual(result, 'Test Return Value')
@@ -146,7 +140,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         """Test that an unsubscribe notification is properly ignored"""
         notification = loader('bounce_notification')
         notification['Type'] = 'UnsubscribeConfirmation'
-        self.request._body = json.dumps(notification)
+        self.request._body = json.dumps(notification).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(
@@ -158,7 +152,7 @@ class BouncyEndpointViewTest(BouncyTestCase):
         """Test that a non-JSON message is properly ignored"""
         notification = loader('bounce_notification')
         notification['Message'] = 'Non JSON Message'
-        self.request._body = json.dumps(notification)
+        self.request._body = json.dumps(notification).encode()
         result = views.endpoint(self.request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(

--- a/django_bouncy/utils.py
+++ b/django_bouncy/utils.py
@@ -1,29 +1,17 @@
-# -*- coding: utf-8 -*-
 """Utility functions for the django_bouncy app"""
-try:
-    import urllib2 as urllib
-except ImportError:
-    import urllib
-
-try:
-    # Python 3
-    from urllib.request import urlopen
-except ImportError:
-    # Python 2.7
-    from urllib import urlopen
-
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
+from urllib.request import urlopen
+from urllib.parse import urlparse
+from urllib.error import HTTPError
 
 import base64
 import re
 import pem
 import logging
-import six
 
-from OpenSSL import crypto
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.primitives.hashes import SHA1
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.exceptions import InvalidSignature
 from django.conf import settings
 from django.core.cache import caches
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -98,8 +86,11 @@ def verify_notification(data):
     Returns True if verfied, False if not verified
     """
     pemfile = grab_keyfile(data["SigningCertURL"])
-    cert = crypto.load_certificate(crypto.FILETYPE_PEM, pemfile)
-    signature = base64.decodebytes(six.b(data["Signature"]))
+    cert = load_pem_x509_certificate(
+        pemfile if isinstance(pemfile, bytes) else pemfile.encode()
+    )
+    public_key = cert.public_key()
+    signature = base64.decodebytes(data["Signature"].encode())
 
     if data["Type"] == "Notification":
         hash_format = NOTIFICATION_HASH_FORMAT
@@ -107,8 +98,10 @@ def verify_notification(data):
         hash_format = SUBSCRIPTION_HASH_FORMAT
 
     try:
-        crypto.verify(cert, signature, six.b(hash_format.format(**data)), "sha1")
-    except crypto.Error:
+        public_key.verify(
+            signature, hash_format.format(**data).encode(), PKCS1v15(), SHA1()
+        )
+    except InvalidSignature:
         return False
     return True
 
@@ -133,7 +126,7 @@ def approve_subscription(data):
     try:
         result = urlopen(url).read()
         logger.info("Subscription Request Sent %s", url)
-    except urllib.HTTPError as error:
+    except HTTPError as error:
         result = error.read()
         logger.warning("HTTP Error Creating Subscription %s", str(result))
 
@@ -142,7 +135,7 @@ def approve_subscription(data):
     )
 
     # Return a 200 Status Code
-    return HttpResponse(six.u(result))
+    return HttpResponse(result)
 
 
 def clean_time(time_string):

--- a/django_bouncy/views.py
+++ b/django_bouncy/views.py
@@ -1,9 +1,6 @@
 """Views for the django_bouncy app"""
 import json
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import re
 import logging
@@ -58,12 +55,7 @@ def endpoint(request):
             return HttpResponseBadRequest('Bad Topic')
 
     # Load the JSON POST Body
-    if isinstance(request.body, str):
-        # requests return str in python 2.7
-        request_body = request.body
-    else:
-        # and return bytes in python 3.4
-        request_body = request.body.decode()
+    request_body = request.body.decode()
     try:
         data = json.loads(request_body)
     except ValueError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-Django==4.2.15
+Django>=4.2
 coverage
-mock
-pyopenssl>=22.1.0
+cryptography>=39
 pem>=21.1.0
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "Django>=4.2",
         "python-dateutil>=2.8",
-        "pyopenssl>=22.1.0",
+        "cryptography>=39",
         "pem>=21.1.0",
     ],
     keywords="aws ses sns seacucumber boto",
@@ -33,5 +33,13 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Topic :: Internet :: WWW/HTTP",
+        "Framework :: Django",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.2",
+        "Framework :: Django :: 6.0",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.12",
     ],
+    python_requires=">=3.10",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,17 @@
 [tox]
-envlist = {py310}-django{42}
+envlist = {py310}-django{42,52},py{312,313,314}-django{42,52,60}
 [testenv]
 basepython =
     py310: python3.10
+    py312: python3.12
+    py313: python3.13
+    py314: python3.14
 deps =
     django42: django<4.2.99
+    django52: django<5.2.99
+    django60: django<6.0.99
     coverage
-    mock
-    pyopenssl>=22.1.0
+    cryptography>=39
     pem>=21.1.0
     python-dateutil
 commands = python manage.py test --settings 'test_settings'


### PR DESCRIPTION
- Remove Python 2/3 compatibility shims (six, __future__ imports, try/except import blocks, class Meta(object))
- Replace pyopenssl with cryptography for certificate verification
- Remove mock dependency in favor of stdlib unittest.mock
- Fix test request bodies to use bytes instead of strings
- Add Django 5.2/6.0 and Python 3.12/3.13/3.14 to test matrix
- Declare python_requires>=3.10 and add framework classifiers